### PR TITLE
Add check on `self::$post`

### DIFF
--- a/gravityforms-update-post.php
+++ b/gravityforms-update-post.php
@@ -1181,7 +1181,7 @@ class gform_update_post
 	 */
 	public static function required_upload_field_validation( $result, $value, $form, $field )
 	{
-		if ( ('post_image' == $field['type'] || 'fileupload' == $field['inputType']) && $field['isRequired'] && ! $result['is_valid'] ) // || 'post_image' == $field['type']
+		if ( ! empty( self::$post->ID ) && ('post_image' == $field['type'] || 'fileupload' == $field['inputType']) && $field['isRequired'] && ! $result['is_valid'] ) // || 'post_image' == $field['type']
 		{
 			if ( ('post_image' == $field['type'] && has_post_thumbnail(self::$post->ID)) || ('fileupload' == $field['inputType'] && get_post_meta( self::$post->ID, $field['postCustomFieldName'], true )) ) {
 				$result['is_valid'] = true;


### PR DESCRIPTION
This required validation filter is only useful when we have an uploaded file, hence a populated `self::$post`, but PHP will issue a warning when attempting to dereference `self::$post->ID` when there's no uploaded file (but the filter still runs) unless wrapped in `isset()` or `empty()`.
